### PR TITLE
ci: switch lint workflow from yarn to npm

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,6 @@ jobs:
       with:
         node-version: '22.x'
     - name: Install dependencies
-      run: yarn install
+      run: npm ci
     - name: Run ESLint
-      run: yarn eslint . --ext .js,.jsx,.ts,.tsx --ignore-pattern 'widgets/**/*.js'
+      run: npx eslint . --ext .js,.jsx,.ts,.tsx --ignore-pattern 'widgets/**/*.js'


### PR DESCRIPTION
## Summary
- Replace \`yarn install\` with \`npm ci\` in the Lint workflow
- Replace \`yarn eslint ...\` with \`npx eslint ...\`

## Why
The repo uses npm (\`package-lock.json\` present, no \`yarn.lock\`) but the Lint workflow installed via yarn, ignoring the lockfile. Yarn would resolve \`homey-api\` to the latest matching version (3.18.x) which now requires \`node: >=24\`, breaking against the workflow's Node 22 — every Dependabot PR's Lint run fails as a result, even though \`Validate Homey App\` (which uses \`npm install\`) is green.

\`npm ci\` respects the lockfile so eslint runs against the same dependency tree as local development and the validate workflow.

## Test plan
- [ ] Lint workflow turns green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)